### PR TITLE
implement /db-test endpoint to fetch and return all data from the dat…

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,10 +1,65 @@
 import { serve } from '@hono/node-server'
 import { Hono } from 'hono'
+import { db } from './database/db.js'
+import { users, threads, emails, draft_responses, agent_actions } from './database/schema.js'
 
 const app = new Hono()
 
 app.get('/', (c) => {
   return c.text('Hello Hono!')
+})
+
+// Test endpoint to fetch all data from database
+app.get('/db-test', async (c) => {
+  try {
+    // Fetch all data from each table
+    const [
+      allUsers,
+      allThreads,
+      allEmails,
+      allDraftResponses,
+      allAgentActions
+    ] = await Promise.all([
+      db.select().from(users),
+      db.select().from(threads),
+      db.select().from(emails),
+      db.select().from(draft_responses),
+      db.select().from(agent_actions)
+    ])
+
+    // Return all data as JSON
+    return c.json({
+      success: true,
+      data: {
+        users: {
+          count: allUsers.length,
+          records: allUsers
+        },
+        threads: {
+          count: allThreads.length,
+          records: allThreads
+        },
+        emails: {
+          count: allEmails.length,
+          records: allEmails
+        },
+        draft_responses: {
+          count: allDraftResponses.length,
+          records: allDraftResponses
+        },
+        agent_actions: {
+          count: allAgentActions.length,
+          records: allAgentActions
+        }
+      }
+    })
+  } catch (error) {
+    console.error('Database test error:', error)
+    return c.json({
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error occurred'
+    }, 500)
+  }
 })
 
 serve({


### PR DESCRIPTION
This pull request introduces a new test endpoint in `backend/src/index.ts` to fetch and return data from all database tables. The change includes importing database modules and schemas, and implementing a route handler for the `/db-test` endpoint.

### Database integration:
* [`backend/src/index.ts`](diffhunk://#diff-c20200a666b149a045e365999f581db8e04687cfc9569bdf4c9477cab954d324R3-R64): Added imports for the database connection (`db`) and schemas (`users`, `threads`, `emails`, `draft_responses`, `agent_actions`). Implemented a new `/db-test` endpoint that queries all tables concurrently and returns their data as JSON, including record counts and error handling.